### PR TITLE
feat: improve edit shopping day UI and fix quantity tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "html",
+    "name": "shopping-list-laravel",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -33,13 +33,16 @@
                 "@eslint/js": "10.0.1",
                 "@types/node": "22.19.17",
                 "@vue/eslint-config-typescript": "14.7.0",
+                "@vue/test-utils": "^2.4.6",
                 "eslint": "10.2.0",
                 "eslint-config-prettier": "10.1.8",
                 "eslint-plugin-vue": "10.8.0",
+                "happy-dom": "^20.8.9",
                 "prettier": "3.8.1",
                 "prettier-plugin-organize-imports": "4.3.0",
                 "prettier-plugin-tailwindcss": "0.7.2",
                 "typescript-eslint": "8.58.1",
+                "vitest": "^4.1.4",
                 "vue-tsc": "3.2.6"
             },
             "optionalDependencies": {
@@ -92,27 +95,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@emnapi/core": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/wasi-threads": {
@@ -411,6 +393,109 @@
                 "@swc/helpers": "^0.5.0"
             }
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -526,6 +611,13 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@one-ini/wasm": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+            "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@oxc-project/types": {
             "version": "0.124.0",
             "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -533,6 +625,17 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
@@ -800,8 +903,14 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
             "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.21",
@@ -1105,6 +1214,24 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1132,6 +1259,7 @@
             "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -1141,6 +1269,23 @@
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
             "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
             "license": "MIT"
+        },
+        "node_modules/@types/whatwg-mimetype": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+            "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.58.1",
@@ -1187,6 +1332,7 @@
             "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.58.1",
                 "@typescript-eslint/types": "8.58.1",
@@ -1401,6 +1547,129 @@
                 "vue": "^3.2.25"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+            "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.4",
+                "@vitest/utils": "4.1.4",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+            "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.4",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+            "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+            "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.4",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+            "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.4",
+                "@vitest/utils": "4.1.4",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+            "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+            "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.4",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@volar/language-core": {
             "version": "2.4.28",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
@@ -1585,6 +1854,17 @@
             "integrity": "sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==",
             "license": "MIT"
         },
+        "node_modules/@vue/test-utils": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+            "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-beautify": "^1.14.9",
+                "vue-component-type-helpers": "^2.0.0"
+            }
+        },
         "node_modules/@vueuse/core": {
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.1.0.tgz",
@@ -1623,12 +1903,23 @@
                 "vue": "^3.5.0"
             }
         },
+        "node_modules/abbrev": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1704,6 +1995,16 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/autoprefixer": {
@@ -1817,6 +2118,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -1850,6 +2152,16 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -1932,6 +2244,16 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
         },
+        "node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/concurrently": {
             "version": "9.2.1",
             "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
@@ -1955,6 +2277,24 @@
             "funding": {
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
             }
+        },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -2029,6 +2369,65 @@
                 "node": ">=8"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/editorconfig": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+            "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@one-ini/wasm": "0.1.1",
+                "commander": "^10.0.0",
+                "minimatch": "^9.0.1",
+                "semver": "^7.5.3"
+            },
+            "bin": {
+                "editorconfig": "bin/editorconfig"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/editorconfig/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/editorconfig/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/editorconfig/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.334",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
@@ -2046,7 +2445,6 @@
             "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
             "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.4.1",
@@ -2060,7 +2458,6 @@
             "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
             "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -2089,6 +2486,13 @@
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es-toolkit": {
             "version": "1.45.1",
@@ -2128,6 +2532,7 @@
             "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -2200,6 +2605,7 @@
             "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "natural-compare": "^1.4.0",
@@ -2368,6 +2774,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2492,6 +2908,23 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/fraction.js": {
             "version": "5.3.4",
             "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -2528,6 +2961,28 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2541,11 +2996,76 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/glob/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "license": "ISC"
+        },
+        "node_modules/happy-dom": {
+            "version": "20.8.9",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+            "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/node": ">=20.0.0",
+                "@types/whatwg-mimetype": "^3.0.2",
+                "@types/ws": "^8.18.1",
+                "entities": "^7.0.1",
+                "whatwg-mimetype": "^3.0.0",
+                "ws": "^8.18.3"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/happy-dom/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -2575,6 +3095,13 @@
             "engines": {
                 "node": ">=0.8.19"
             }
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
@@ -2625,6 +3152,22 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
         "node_modules/jiti": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2632,6 +3175,38 @@
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/js-beautify": {
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+            "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "config-chain": "^1.1.13",
+                "editorconfig": "^1.0.4",
+                "glob": "^10.4.2",
+                "js-cookie": "^3.0.5",
+                "nopt": "^7.2.1"
+            },
+            "bin": {
+                "css-beautify": "js/bin/css-beautify.js",
+                "html-beautify": "js/bin/html-beautify.js",
+                "js-beautify": "js/bin/js-beautify.js"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/js-cookie": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/json-buffer": {
@@ -2994,6 +3569,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/lucide": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/lucide/-/lucide-1.8.0.tgz",
@@ -3058,6 +3640,16 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3102,6 +3694,22 @@
             "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
             "license": "MIT"
         },
+        "node_modules/nopt": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^2.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/normalize-range": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
@@ -3123,6 +3731,17 @@
             "funding": {
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
         },
         "node_modules/optionator": {
             "version": "0.9.4",
@@ -3174,6 +3793,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
         "node_modules/path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -3200,6 +3826,30 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -3238,6 +3888,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -3269,6 +3920,7 @@
             "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -3285,6 +3937,7 @@
             "integrity": "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "prettier": ">=2.0",
                 "typescript": ">=2.9",
@@ -3375,6 +4028,13 @@
                 }
             }
         },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3390,6 +4050,7 @@
             "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.4.0.tgz",
             "integrity": "sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tweetnacl": "^1.0.3"
             }
@@ -3701,6 +4362,26 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/socket.io-client": {
             "version": "4.8.3",
             "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -3722,7 +4403,6 @@
             "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
             "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.4.1"
@@ -3740,6 +4420,20 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+            "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3754,10 +4448,40 @@
                 "node": ">=8"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -3795,7 +4519,8 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
             "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tailwindcss-animate": {
             "version": "1.0.7",
@@ -3817,6 +4542,23 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/tinyglobby": {
@@ -3857,11 +4599,22 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -3929,6 +4682,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
             "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4020,6 +4774,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
             "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
@@ -4114,6 +4869,109 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+            "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.4",
+                "@vitest/mocker": "4.1.4",
+                "@vitest/pretty-format": "4.1.4",
+                "@vitest/runner": "4.1.4",
+                "@vitest/snapshot": "4.1.4",
+                "@vitest/spy": "4.1.4",
+                "@vitest/utils": "4.1.4",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.4",
+                "@vitest/browser-preview": "4.1.4",
+                "@vitest/browser-webdriverio": "4.1.4",
+                "@vitest/coverage-istanbul": "4.1.4",
+                "@vitest/coverage-v8": "4.1.4",
+                "@vitest/ui": "4.1.4",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/vscode-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -4126,6 +4984,7 @@
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
             "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.5.25",
                 "@vue/compiler-sfc": "3.5.25",
@@ -4141,6 +5000,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/vue-component-type-helpers": {
+            "version": "2.2.12",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+            "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vue-eslint-parser": {
             "version": "10.4.0",
@@ -4185,6 +5051,7 @@
             "integrity": "sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@volar/typescript": "2.4.28",
                 "@vue/language-core": "3.2.6"
@@ -4194,6 +5061,16 @@
             },
             "peerDependencies": {
                 "typescript": ">=5.0.0"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/which": {
@@ -4210,6 +5087,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {
@@ -4239,12 +5133,30 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/ws": {
             "version": "8.18.3",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
             "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -4275,7 +5187,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
             "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }

--- a/package.json
+++ b/package.json
@@ -7,19 +7,23 @@
         "dev": "vite",
         "format": "prettier --write resources/",
         "format:check": "prettier --check resources/",
-        "lint": "eslint . --fix"
+        "lint": "eslint . --fix",
+        "test": "vitest"
     },
     "devDependencies": {
         "@eslint/js": "10.0.1",
         "@types/node": "22.19.17",
         "@vue/eslint-config-typescript": "14.7.0",
+        "@vue/test-utils": "^2.4.6",
         "eslint": "10.2.0",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-vue": "10.8.0",
+        "happy-dom": "^20.8.9",
         "prettier": "3.8.1",
         "prettier-plugin-organize-imports": "4.3.0",
         "prettier-plugin-tailwindcss": "0.7.2",
         "typescript-eslint": "8.58.1",
+        "vitest": "^4.1.4",
         "vue-tsc": "3.2.6"
     },
     "dependencies": {

--- a/resources/js/components/shopping/DeleteShoppingDay.vue
+++ b/resources/js/components/shopping/DeleteShoppingDay.vue
@@ -40,7 +40,7 @@ function closeModal() {
 <template>
     <AppDialog>
         <DialogTrigger as-child>
-            <AppButton class="basis-1/2" variant="destructive">
+            <AppButton variant="destructive">
                 Borrar
             </AppButton>
         </DialogTrigger>

--- a/resources/js/components/shopping/ProductCheckboxItem.vue
+++ b/resources/js/components/shopping/ProductCheckboxItem.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { Product } from "@/types/Product"
+import Checkbox from "@/components/ui/checkbox/Checkbox.vue"
+import { formatCurrency } from "@/composables/formatHelpers"
+
+interface Props {
+    product: Product
+    checked: boolean
+    class?: string
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ (e: "update:checked", value: boolean): void }>()
+</script>
+
+<template>
+    <label
+        class="flex items-center gap-2.5 px-2 py-2 rounded-md transition-colors cursor-pointer select-none"
+        :class="checked ? 'bg-primary/10' : 'hover:bg-muted'"
+    >
+        <Checkbox
+            :checked="checked"
+            @update:checked="emit('update:checked', $event as boolean)"
+        />
+        <span
+            data-testid="product-name"
+            class="flex-1 truncate text-sm"
+            :class="[
+                checked ? 'font-medium' : '',
+                checked && !product.lastPrice ? 'underline' : '',
+            ]"
+        >
+            {{ product.name }}
+        </span>
+        <span
+            v-if="product.lastPrice"
+            data-testid="last-price"
+            class="text-xs text-muted-foreground tabular-nums shrink-0"
+        >
+            {{ formatCurrency(product.lastPrice) }}
+        </span>
+    </label>
+</template>

--- a/resources/js/components/shopping/QuantityControl.vue
+++ b/resources/js/components/shopping/QuantityControl.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+const quantity = defineModel<number>({ default: 1 })
+
+function decrement() {
+    if (quantity.value <= 1) return
+    quantity.value = Math.ceil(quantity.value - 1)
+}
+
+function increment() {
+    quantity.value = Math.floor(quantity.value + 1)
+}
+</script>
+
+<template>
+    <div class="flex items-center gap-1">
+        <button
+            type="button"
+            data-testid="decrement"
+            class="size-6 rounded bg-secondary flex items-center justify-center disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
+            :disabled="quantity <= 1"
+            @click="decrement"
+        >
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+                stroke="currentColor"
+                class="size-3"
+            >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M18 12H6" />
+            </svg>
+        </button>
+
+        <span class="w-6 text-center text-sm tabular-nums select-none">
+            {{ quantity }}
+        </span>
+
+        <button
+            type="button"
+            data-testid="increment"
+            class="size-6 rounded bg-primary text-primary-foreground flex items-center justify-center shrink-0"
+            @click="increment"
+        >
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+                stroke="currentColor"
+                class="size-3"
+            >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" />
+            </svg>
+        </button>
+    </div>
+</template>

--- a/resources/js/components/shopping/__tests__/ProductCheckboxItem.test.ts
+++ b/resources/js/components/shopping/__tests__/ProductCheckboxItem.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { mount } from "@vue/test-utils"
+import type { Product } from "@/types/Product"
+
+vi.mock("@inertiajs/vue3", () => ({
+    usePage: () => ({ props: { lang: "es-MX" } }),
+}))
+
+// Import after mock is set up
+const { default: ProductCheckboxItem } = await import(
+    "../ProductCheckboxItem.vue"
+)
+
+const productWithPrice: Product = {
+    id: "1",
+    name: "Leche",
+    lastPrice: 25.5,
+}
+
+const productWithoutPrice: Product = {
+    id: "2",
+    name: "Champú",
+}
+
+function mountItem(product: Product, checked: boolean) {
+    return mount(ProductCheckboxItem, {
+        props: { product, checked },
+        global: {
+            stubs: { Checkbox: true },
+        },
+    })
+}
+
+describe("ProductCheckboxItem", () => {
+    describe("rendering", () => {
+        it("renders the product name", () => {
+            const wrapper = mountItem(productWithPrice, false)
+            expect(wrapper.text()).toContain("Leche")
+        })
+
+        it("renders lastPrice when product has one", () => {
+            const wrapper = mountItem(productWithPrice, false)
+            expect(wrapper.text()).toMatch(/\$|MXN|25/)
+        })
+
+        it("does not render price when product has no lastPrice", () => {
+            const wrapper = mountItem(productWithoutPrice, false)
+            expect(wrapper.find("[data-testid='last-price']").exists()).toBe(
+                false
+            )
+        })
+    })
+
+    describe("checked state styling", () => {
+        it("applies highlight class when checked", () => {
+            const wrapper = mountItem(productWithPrice, true)
+            expect(wrapper.classes()).toContain("bg-primary/10")
+        })
+
+        it("does not apply highlight class when unchecked", () => {
+            const wrapper = mountItem(productWithPrice, false)
+            expect(wrapper.classes()).not.toContain("bg-primary/10")
+        })
+
+        it("applies font-medium to name when checked", () => {
+            const wrapper = mountItem(productWithPrice, true)
+            const nameSpan = wrapper.find("[data-testid='product-name']")
+            expect(nameSpan.classes()).toContain("font-medium")
+        })
+
+        it("does not apply font-medium to name when unchecked", () => {
+            const wrapper = mountItem(productWithPrice, false)
+            const nameSpan = wrapper.find("[data-testid='product-name']")
+            expect(nameSpan.classes()).not.toContain("font-medium")
+        })
+
+        it("underlines name when checked and product has no lastPrice", () => {
+            const wrapper = mountItem(productWithoutPrice, true)
+            const nameSpan = wrapper.find("[data-testid='product-name']")
+            expect(nameSpan.classes()).toContain("underline")
+        })
+
+        it("does not underline name when checked and product has a lastPrice", () => {
+            const wrapper = mountItem(productWithPrice, true)
+            const nameSpan = wrapper.find("[data-testid='product-name']")
+            expect(nameSpan.classes()).not.toContain("underline")
+        })
+    })
+
+    describe("events", () => {
+        it("emits update:checked with true when Checkbox emits update:checked true", async () => {
+            const wrapper = mountItem(productWithPrice, false)
+            await wrapper
+                .findComponent({ name: "Checkbox" })
+                .vm.$emit("update:checked", true)
+            expect(wrapper.emitted("update:checked")).toBeTruthy()
+            expect(wrapper.emitted("update:checked")![0]).toEqual([true])
+        })
+
+        it("emits update:checked with false when Checkbox emits update:checked false", async () => {
+            const wrapper = mountItem(productWithPrice, true)
+            await wrapper
+                .findComponent({ name: "Checkbox" })
+                .vm.$emit("update:checked", false)
+            expect(wrapper.emitted("update:checked")).toBeTruthy()
+            expect(wrapper.emitted("update:checked")![0]).toEqual([false])
+        })
+    })
+})

--- a/resources/js/components/shopping/__tests__/QuantityControl.test.ts
+++ b/resources/js/components/shopping/__tests__/QuantityControl.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest"
+import { mount } from "@vue/test-utils"
+import QuantityControl from "../QuantityControl.vue"
+
+function mountControl(quantity: number) {
+    return mount(QuantityControl, {
+        props: { modelValue: quantity },
+    })
+}
+
+describe("QuantityControl", () => {
+    describe("rendering", () => {
+        it("displays the current quantity", () => {
+            const wrapper = mountControl(3)
+            expect(wrapper.text()).toContain("3")
+        })
+
+        it("displays quantity of 1", () => {
+            const wrapper = mountControl(1)
+            expect(wrapper.text()).toContain("1")
+        })
+    })
+
+    describe("increment", () => {
+        it("emits update:modelValue with incremented value on plus click", async () => {
+            const wrapper = mountControl(2)
+            await wrapper
+                .find("[data-testid='increment']")
+                .trigger("click")
+            expect(wrapper.emitted("update:modelValue")![0]).toEqual([3])
+        })
+    })
+
+    describe("decrement", () => {
+        it("emits update:modelValue with decremented value on minus click", async () => {
+            const wrapper = mountControl(3)
+            await wrapper
+                .find("[data-testid='decrement']")
+                .trigger("click")
+            expect(wrapper.emitted("update:modelValue")![0]).toEqual([2])
+        })
+
+        it("disables minus button when quantity is 1", () => {
+            const wrapper = mountControl(1)
+            const button = wrapper.find("[data-testid='decrement']")
+            expect(button.attributes("disabled")).toBeDefined()
+        })
+
+        it("does not emit when minus is clicked at quantity 1", async () => {
+            const wrapper = mountControl(1)
+            await wrapper
+                .find("[data-testid='decrement']")
+                .trigger("click")
+            expect(wrapper.emitted("update:modelValue")).toBeUndefined()
+        })
+    })
+})

--- a/resources/js/composables/__tests__/useProductSelection.test.ts
+++ b/resources/js/composables/__tests__/useProductSelection.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest"
+import { ref } from "vue"
+import type { Product } from "@/types/Product"
+import type { ShoppingDayItem } from "@/types/ShoppingDayItem"
+import { useProductSelection } from "@/composables/useProductSelection"
+
+const products: Product[] = [
+    { id: "a", name: "Leche", searchIndex: 2, shoppingIndex: 1 },
+    { id: "b", name: "Pan", searchIndex: 1, shoppingIndex: 3, lastPrice: 20 },
+    { id: "c", name: "Agua-6", searchIndex: 3, shoppingIndex: 2 },
+    { id: "d", name: "Champú", searchIndex: 4, shoppingIndex: 4 },
+]
+
+describe("useProductSelection", () => {
+    describe("filteredProducts", () => {
+        it("returns all products when query is empty", () => {
+            const { filteredProducts } = useProductSelection(ref(products), [])
+            expect(filteredProducts.value).toHaveLength(4)
+        })
+
+        it("filters products case-insensitively by name", () => {
+            const { filteredProducts, searchQuery } = useProductSelection(
+                ref(products),
+                []
+            )
+            searchQuery.value = "le"
+            expect(filteredProducts.value).toHaveLength(1)
+            expect(filteredProducts.value[0].id).toBe("a")
+        })
+
+        it("returns empty array when no products match", () => {
+            const { filteredProducts, searchQuery } = useProductSelection(
+                ref(products),
+                []
+            )
+            searchQuery.value = "xyz"
+            expect(filteredProducts.value).toHaveLength(0)
+        })
+
+        it("ignores leading/trailing whitespace in query", () => {
+            const { filteredProducts, searchQuery } = useProductSelection(
+                ref(products),
+                []
+            )
+            searchQuery.value = "  pan  "
+            expect(filteredProducts.value).toHaveLength(1)
+            expect(filteredProducts.value[0].id).toBe("b")
+        })
+    })
+
+    describe("selectedProducts", () => {
+        it("returns only products whose ids are selected", () => {
+            const { selectedProducts } = useProductSelection(
+                ref(products),
+                ["a", "c"]
+            )
+            expect(selectedProducts.value.map((p) => p.id)).toEqual(
+                expect.arrayContaining(["a", "c"])
+            )
+            expect(selectedProducts.value).toHaveLength(2)
+        })
+
+        it("is empty when no products are selected", () => {
+            const { selectedProducts } = useProductSelection(ref(products), [])
+            expect(selectedProducts.value).toHaveLength(0)
+        })
+
+        it("is sorted by shoppingIndex ascending", () => {
+            const { selectedProducts } = useProductSelection(
+                ref(products),
+                ["a", "b", "c"]
+            )
+            const indices = selectedProducts.value.map(
+                (p) => p.shoppingIndex ?? 0
+            )
+            expect(indices).toEqual([...indices].sort((x, y) => x - y))
+        })
+
+        it("only includes filtered products when search is active", () => {
+            const { selectedProducts, searchQuery } = useProductSelection(
+                ref(products),
+                ["a", "b"]
+            )
+            searchQuery.value = "pan"
+            expect(selectedProducts.value.map((p) => p.id)).toEqual(["b"])
+        })
+    })
+
+    describe("availableProducts", () => {
+        it("returns products not in the selected list", () => {
+            const { availableProducts } = useProductSelection(
+                ref(products),
+                ["a"]
+            )
+            expect(availableProducts.value.map((p) => p.id)).not.toContain("a")
+            expect(availableProducts.value).toHaveLength(3)
+        })
+
+        it("is sorted by searchIndex ascending", () => {
+            const { availableProducts } = useProductSelection(
+                ref(products),
+                []
+            )
+            const indices = availableProducts.value.map(
+                (p) => p.searchIndex ?? 0
+            )
+            expect(indices).toEqual([...indices].sort((x, y) => x - y))
+        })
+
+        it("only includes filtered products when search is active", () => {
+            const { availableProducts, searchQuery } = useProductSelection(
+                ref(products),
+                []
+            )
+            searchQuery.value = "agua"
+            expect(availableProducts.value.map((p) => p.id)).toEqual(["c"])
+        })
+    })
+
+    describe("toggleProduct", () => {
+        it("adds a product id to selected when checked", () => {
+            const { selectedIds, toggleProduct } = useProductSelection(
+                ref(products),
+                []
+            )
+            toggleProduct("b", true)
+            expect(selectedIds.value).toContain("b")
+        })
+
+        it("removes a product id from selected when unchecked", () => {
+            const { selectedIds, toggleProduct } = useProductSelection(
+                ref(products),
+                ["a", "b"]
+            )
+            toggleProduct("a", false)
+            expect(selectedIds.value).not.toContain("a")
+            expect(selectedIds.value).toContain("b")
+        })
+
+        it("does not duplicate ids when toggling an already-selected product", () => {
+            const { selectedIds, toggleProduct } = useProductSelection(
+                ref(products),
+                ["b"]
+            )
+            toggleProduct("b", true)
+            expect(selectedIds.value.filter((id) => id === "b")).toHaveLength(1)
+        })
+    })
+
+    describe("item quantities", () => {
+        const existingItems: ShoppingDayItem[] = [
+            {
+                id: "item-1",
+                product: products[0],
+                index: 1,
+                unitPrice: 0,
+                quantity: 2,
+            },
+            {
+                id: "item-2",
+                product: products[2],
+                index: 2,
+                unitPrice: 0,
+                quantity: 6,
+            },
+        ]
+
+        it("initialises quantities from existing items", () => {
+            const { getQuantity } = useProductSelection(
+                ref(products),
+                ["a", "c"],
+                existingItems
+            )
+            expect(getQuantity("item-1")).toBe(2)
+            expect(getQuantity("item-2")).toBe(6)
+        })
+
+        it("returns 1 as default quantity for items with no record", () => {
+            const { getQuantity } = useProductSelection(ref(products), [])
+            expect(getQuantity("unknown-item")).toBe(1)
+        })
+
+        it("setQuantity updates the quantity for a given item id", () => {
+            const { getQuantity, setQuantity } = useProductSelection(
+                ref(products),
+                ["a"],
+                existingItems
+            )
+            setQuantity("item-1", 5)
+            expect(getQuantity("item-1")).toBe(5)
+        })
+
+        it("setQuantity ignores values less than or equal to zero", () => {
+            const { getQuantity, setQuantity } = useProductSelection(
+                ref(products),
+                ["a"],
+                existingItems
+            )
+            setQuantity("item-1", 0)
+            setQuantity("item-1", -3)
+            expect(getQuantity("item-1")).toBe(2)
+        })
+
+        it("getItemsPayload returns array of id/quantity pairs for all tracked items", () => {
+            const { setQuantity, getItemsPayload } = useProductSelection(
+                ref(products),
+                ["a", "c"],
+                existingItems
+            )
+            setQuantity("item-2", 3)
+            const payload = getItemsPayload()
+            expect(payload).toContainEqual({ id: "item-1", quantity: 2 })
+            expect(payload).toContainEqual({ id: "item-2", quantity: 3 })
+        })
+    })
+})

--- a/resources/js/composables/__tests__/useProductSelection.test.ts
+++ b/resources/js/composables/__tests__/useProductSelection.test.ts
@@ -165,29 +165,29 @@ describe("useProductSelection", () => {
             },
         ]
 
-        it("initialises quantities from existing items", () => {
+        it("initialises quantities from existing items by product id", () => {
             const { getQuantity } = useProductSelection(
                 ref(products),
                 ["a", "c"],
                 existingItems
             )
-            expect(getQuantity("item-1")).toBe(2)
-            expect(getQuantity("item-2")).toBe(6)
+            expect(getQuantity("a")).toBe(2)
+            expect(getQuantity("c")).toBe(6)
         })
 
-        it("returns 1 as default quantity for items with no record", () => {
+        it("returns 1 as default quantity for products with no record", () => {
             const { getQuantity } = useProductSelection(ref(products), [])
-            expect(getQuantity("unknown-item")).toBe(1)
+            expect(getQuantity("unknown-product")).toBe(1)
         })
 
-        it("setQuantity updates the quantity for a given item id", () => {
+        it("setQuantity updates the quantity for a given product id", () => {
             const { getQuantity, setQuantity } = useProductSelection(
                 ref(products),
                 ["a"],
                 existingItems
             )
-            setQuantity("item-1", 5)
-            expect(getQuantity("item-1")).toBe(5)
+            setQuantity("a", 5)
+            expect(getQuantity("a")).toBe(5)
         })
 
         it("setQuantity ignores values less than or equal to zero", () => {
@@ -196,21 +196,33 @@ describe("useProductSelection", () => {
                 ["a"],
                 existingItems
             )
-            setQuantity("item-1", 0)
-            setQuantity("item-1", -3)
-            expect(getQuantity("item-1")).toBe(2)
+            setQuantity("a", 0)
+            setQuantity("a", -3)
+            expect(getQuantity("a")).toBe(2)
         })
 
-        it("getItemsPayload returns array of id/quantity pairs for all tracked items", () => {
+        it("getItemsPayload maps item ids to locally tracked quantities", () => {
             const { setQuantity, getItemsPayload } = useProductSelection(
                 ref(products),
                 ["a", "c"],
                 existingItems
             )
-            setQuantity("item-2", 3)
-            const payload = getItemsPayload()
+            setQuantity("c", 3)
+            const payload = getItemsPayload(existingItems)
             expect(payload).toContainEqual({ id: "item-1", quantity: 2 })
             expect(payload).toContainEqual({ id: "item-2", quantity: 3 })
+        })
+
+        it("getItemsPayload only includes items that exist server-side", () => {
+            const { getItemsPayload } = useProductSelection(
+                ref(products),
+                ["a", "b"],
+                existingItems
+            )
+            // product "b" has no server item — should not appear in payload
+            const payload = getItemsPayload(existingItems)
+            expect(payload.map((p) => p.id)).not.toContain("b")
+            expect(payload).toHaveLength(existingItems.length)
         })
     })
 })

--- a/resources/js/composables/useProductSelection.ts
+++ b/resources/js/composables/useProductSelection.ts
@@ -1,0 +1,74 @@
+import { computed, ref, type Ref } from "vue"
+import type { Product } from "@/types/Product"
+import type { ShoppingDayItem } from "@/types/ShoppingDayItem"
+
+export function useProductSelection(
+    products: Ref<Product[]>,
+    initialSelectedIds: string[],
+    initialItems: ShoppingDayItem[] = []
+) {
+    const searchQuery = ref("")
+    const selectedIds = ref<string[]>([...initialSelectedIds])
+
+    const itemQuantities = ref<Record<string, number>>(
+        Object.fromEntries(initialItems.map((item) => [item.id, item.quantity ?? 1]))
+    )
+
+    function getQuantity(itemId: string): number {
+        return itemQuantities.value[itemId] ?? 1
+    }
+
+    function setQuantity(itemId: string, quantity: number) {
+        if (quantity <= 0) return
+        itemQuantities.value = { ...itemQuantities.value, [itemId]: quantity }
+    }
+
+    function getItemsPayload(): { id: string; quantity: number }[] {
+        return Object.entries(itemQuantities.value).map(([id, quantity]) => ({
+            id,
+            quantity,
+        }))
+    }
+
+    const filteredProducts = computed(() => {
+        const query = searchQuery.value.toLowerCase().trim()
+        if (!query) return products.value
+        return products.value.filter(({ name }) =>
+            name.toLowerCase().includes(query)
+        )
+    })
+
+    const selectedProducts = computed(() =>
+        filteredProducts.value
+            .filter(({ id }) => selectedIds.value.includes(id))
+            .sort((a, b) => (a.shoppingIndex ?? 0) - (b.shoppingIndex ?? 0))
+    )
+
+    const availableProducts = computed(() =>
+        filteredProducts.value
+            .filter(({ id }) => !selectedIds.value.includes(id))
+            .sort((a, b) => (a.searchIndex ?? 0) - (b.searchIndex ?? 0))
+    )
+
+    function toggleProduct(id: string, checked: boolean) {
+        if (checked) {
+            if (!selectedIds.value.includes(id)) {
+                selectedIds.value = [...selectedIds.value, id]
+            }
+        } else {
+            selectedIds.value = selectedIds.value.filter((p) => p !== id)
+        }
+    }
+
+    return {
+        searchQuery,
+        selectedIds,
+        filteredProducts,
+        selectedProducts,
+        availableProducts,
+        toggleProduct,
+        getQuantity,
+        setQuantity,
+        getItemsPayload,
+    }
+}

--- a/resources/js/composables/useProductSelection.ts
+++ b/resources/js/composables/useProductSelection.ts
@@ -1,4 +1,4 @@
-import { computed, ref, type Ref } from "vue"
+import { computed, reactive, ref, type Ref } from "vue"
 import type { Product } from "@/types/Product"
 import type { ShoppingDayItem } from "@/types/ShoppingDayItem"
 
@@ -10,23 +10,23 @@ export function useProductSelection(
     const searchQuery = ref("")
     const selectedIds = ref<string[]>([...initialSelectedIds])
 
-    const itemQuantities = ref<Record<string, number>>(
-        Object.fromEntries(initialItems.map((item) => [item.id, item.quantity ?? 1]))
+    const itemQuantities = reactive<Record<string, number>>(
+        Object.fromEntries(initialItems.map((item) => [item.product.id, item.quantity ?? 1]))
     )
 
-    function getQuantity(itemId: string): number {
-        return itemQuantities.value[itemId] ?? 1
+    function getQuantity(productId: string): number {
+        return itemQuantities[productId] ?? 1
     }
 
-    function setQuantity(itemId: string, quantity: number) {
+    function setQuantity(productId: string, quantity: number) {
         if (quantity <= 0) return
-        itemQuantities.value = { ...itemQuantities.value, [itemId]: quantity }
+        itemQuantities[productId] = quantity
     }
 
-    function getItemsPayload(): { id: string; quantity: number }[] {
-        return Object.entries(itemQuantities.value).map(([id, quantity]) => ({
-            id,
-            quantity,
+    function getItemsPayload(items: ShoppingDayItem[]): { id: string; quantity: number }[] {
+        return items.map((item) => ({
+            id: item.id,
+            quantity: itemQuantities[item.product.id] ?? 1,
         }))
     }
 

--- a/resources/js/pages/shopping/ShoppingDayEdit.vue
+++ b/resources/js/pages/shopping/ShoppingDayEdit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue"
+import { computed, ref } from "vue"
 import { useDebounceFn } from "@vueuse/core"
 import { Head, router, useForm } from "@inertiajs/vue3"
 import type { Page, PageProps } from "@inertiajs/core"
@@ -9,7 +9,6 @@ import AppLayout from "@/layouts/AppLayout.vue"
 import type { BreadcrumbItem } from "@/types"
 import type { Product } from "@/types/Product"
 import type { ShoppingDay } from "@/types/ShoppingDay"
-import type { ShoppingDayItem } from "@/types/ShoppingDayItem"
 import AppButton from "@/components/ui/button/Button.vue"
 import AppInput from "@/components/ui/input/Input.vue"
 import Separator from "@/components/ui/separator/Separator.vue"
@@ -64,26 +63,25 @@ const {
     props.shoppingDay.items ?? []
 )
 
-// Helper: look up ShoppingDayItem by product id
-function itemForProduct(productId: string): ShoppingDayItem | undefined {
-    return props.shoppingDay.items?.find(
-        ({ product }) => product.id === productId
-    )
-}
+type SaveStatus = "idle" | "pending" | "saving" | "saved"
+const saveStatus = ref<SaveStatus>("idle")
+let savedTimer: ReturnType<typeof setTimeout> | null = null
 
 const autoSaveItems = useDebounceFn(function autoSaveItems() {
     updateProductsForm.products = selectedIds.value
-    updateProductsForm.items = getItemsPayload()
+    updateProductsForm.items = getItemsPayload(props.shoppingDay.items ?? [])
     handleSaveShoppingDay({ async: true })
 }, 6 * 1000)
 
 function handleToggleProduct(id: string, checked: boolean) {
     toggleProduct(id, checked)
+    saveStatus.value = "pending"
     autoSaveItems()
 }
 
-function handleQuantityChange(itemId: string, quantity: number) {
-    setQuantity(itemId, quantity)
+function handleQuantityChange(productId: string, quantity: number) {
+    setQuantity(productId, quantity)
+    saveStatus.value = "pending"
     autoSaveItems()
 }
 
@@ -110,7 +108,7 @@ const { form: productForm, handleSubmit: handleNewProduct } =
 
 function handleSaveProducts() {
     updateProductsForm.products = selectedIds.value
-    updateProductsForm.items = getItemsPayload()
+    updateProductsForm.items = getItemsPayload(props.shoppingDay.items ?? [])
     handleSaveShoppingDay({ async: false })
 }
 
@@ -122,6 +120,9 @@ function handleSaveShoppingDay({ async }: { async: boolean }) {
         {
             async,
             preserveScroll: true,
+            onStart: () => {
+                if (async) saveStatus.value = "saving"
+            },
             onSuccess: () => {
                 if (!async) {
                     return router.get(
@@ -130,6 +131,27 @@ function handleSaveShoppingDay({ async }: { async: boolean }) {
                         })
                     )
                 }
+                saveStatus.value = "saved"
+                if (savedTimer) clearTimeout(savedTimer)
+                savedTimer = setTimeout(() => {
+                    saveStatus.value = "idle"
+                }, 2000)
+
+                // Newly-toggled products are created with qty=1 by the server.
+                // If the user changed the quantity before the first save, sync it now.
+                const staleItems = (props.shoppingDay.items ?? []).filter(
+                    (item) => getQuantity(item.product.id) !== item.quantity
+                )
+                if (staleItems.length > 0) {
+                    updateProductsForm.products = selectedIds.value
+                    updateProductsForm.items = getItemsPayload(
+                        props.shoppingDay.items ?? []
+                    )
+                    handleSaveShoppingDay({ async: true })
+                }
+            },
+            onError: () => {
+                if (async) saveStatus.value = "idle"
             },
         }
     )
@@ -155,10 +177,7 @@ const estimatedTotal = computed(() =>
         const product = props.products.find((p) => p.id === productId)
         if (!product || !product.lastPrice) return total
 
-        const item = itemForProduct(productId)
-        const quantity = item
-            ? getQuantity(item.id)
-            : parseInt(product.name.split("-").at(1) ?? "") || 1
+        const quantity = getQuantity(productId)
 
         return total + product.lastPrice * quantity
     }, 0)
@@ -188,6 +207,9 @@ const estimatedTotal = computed(() =>
 
             <div class="text-sm text-muted-foreground">
                 Total estimado: {{ formatCurrency(estimatedTotal) }}
+                <span v-if="saveStatus === 'pending'"> · Pendiente…</span>
+                <span v-else-if="saveStatus === 'saving'"> · Guardando…</span>
+                <span v-else-if="saveStatus === 'saved'"> · Guardado</span>
             </div>
 
             <div class="relative">
@@ -247,15 +269,9 @@ const estimatedTotal = computed(() =>
                                 "
                             />
                             <QuantityControl
-                                v-if="itemForProduct(product.id)"
-                                :modelValue="
-                                    getQuantity(itemForProduct(product.id)!.id)
-                                "
+                                :modelValue="getQuantity(product.id)"
                                 @update:modelValue="
-                                    handleQuantityChange(
-                                        itemForProduct(product.id)!.id,
-                                        $event
-                                    )
+                                    handleQuantityChange(product.id, $event)
                                 "
                             />
                         </div>
@@ -273,7 +289,7 @@ const estimatedTotal = computed(() =>
                     <p class="text-xs font-medium text-muted-foreground px-2 mb-1">
                         Disponibles ({{ availableProducts.length }})
                     </p>
-                    <div class="columns-2">
+                    <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-2 gap-y-0.5">
                         <ProductCheckboxItem
                             v-for="product in availableProducts"
                             :key="product.id"
@@ -287,14 +303,21 @@ const estimatedTotal = computed(() =>
                 </div>
 
                 <p
-                    v-if="filteredProducts.length === 0"
+                    v-if="filteredProducts.length === 0 && searchQuery"
                     class="text-sm text-muted-foreground px-2 py-4 text-center"
                 >
                     Sin resultados para "{{ searchQuery }}"
                 </p>
+
+                <p
+                    v-if="computedProducts.length === 0 && !searchQuery"
+                    class="text-sm text-muted-foreground px-2 py-4 text-center"
+                >
+                    Aún no tienes productos. Agrega el primero arriba.
+                </p>
             </form>
 
-            <div class="flex justify-end">
+            <div class="flex justify-end mt-6 pt-6 border-t">
                 <DeleteShoppingDay :shoppingDay="shoppingDay" />
             </div>
         </div>

--- a/resources/js/pages/shopping/ShoppingDayEdit.vue
+++ b/resources/js/pages/shopping/ShoppingDayEdit.vue
@@ -3,16 +3,23 @@ import { computed } from "vue"
 import { useDebounceFn } from "@vueuse/core"
 import { Head, router, useForm } from "@inertiajs/vue3"
 import type { Page, PageProps } from "@inertiajs/core"
+import { Search, X } from "lucide-vue-next"
 
 import AppLayout from "@/layouts/AppLayout.vue"
 import type { BreadcrumbItem } from "@/types"
 import type { Product } from "@/types/Product"
 import type { ShoppingDay } from "@/types/ShoppingDay"
+import type { ShoppingDayItem } from "@/types/ShoppingDayItem"
 import AppButton from "@/components/ui/button/Button.vue"
+import AppInput from "@/components/ui/input/Input.vue"
+import Separator from "@/components/ui/separator/Separator.vue"
 import NewProductInput from "@/components/shopping/NewProductInput.vue"
+import ProductCheckboxItem from "@/components/shopping/ProductCheckboxItem.vue"
+import QuantityControl from "@/components/shopping/QuantityControl.vue"
 import { formatCurrency, formatDate } from "@/composables/formatHelpers"
 import { useCreateNewProductToShoppingDay } from "@/composables/useCreateNewProductToShoppingDay"
 import { useEditShoppingDay } from "@/composables/useEditShoppingDay"
+import { useProductSelection } from "@/composables/useProductSelection"
 import EditShoppingDayDateInput from "@/components/shopping/EditShoppingDayDateInput.vue"
 import DeleteShoppingDay from "@/components/shopping/DeleteShoppingDay.vue"
 
@@ -38,11 +45,47 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => [
 
 const updateProductsForm = useForm({
     products: props.shoppingDay.items?.map(({ product }) => product.id) ?? [],
+    items: [] as { id: string; quantity: number }[],
 })
 
+const {
+    searchQuery,
+    selectedIds,
+    filteredProducts,
+    selectedProducts,
+    availableProducts,
+    toggleProduct,
+    getQuantity,
+    setQuantity,
+    getItemsPayload,
+} = useProductSelection(
+    computedProducts,
+    updateProductsForm.products,
+    props.shoppingDay.items ?? []
+)
+
+// Helper: look up ShoppingDayItem by product id
+function itemForProduct(productId: string): ShoppingDayItem | undefined {
+    return props.shoppingDay.items?.find(
+        ({ product }) => product.id === productId
+    )
+}
+
 const autoSaveItems = useDebounceFn(function autoSaveItems() {
+    updateProductsForm.products = selectedIds.value
+    updateProductsForm.items = getItemsPayload()
     handleSaveShoppingDay({ async: true })
 }, 6 * 1000)
+
+function handleToggleProduct(id: string, checked: boolean) {
+    toggleProduct(id, checked)
+    autoSaveItems()
+}
+
+function handleQuantityChange(itemId: string, quantity: number) {
+    setQuantity(itemId, quantity)
+    autoSaveItems()
+}
 
 const { form: productForm, handleSubmit: handleNewProduct } =
     useCreateNewProductToShoppingDay(
@@ -55,15 +98,19 @@ const { form: productForm, handleSubmit: handleNewProduct } =
                     return
                 }
 
-                updateProductsForm.products =
+                const newIds =
                     responseProps.shoppingDay.items?.map(
                         ({ product }) => product.id
                     ) ?? []
+                updateProductsForm.products = newIds
+                selectedIds.value = newIds
             },
         }
     )
 
 function handleSaveProducts() {
+    updateProductsForm.products = selectedIds.value
+    updateProductsForm.items = getItemsPayload()
     handleSaveShoppingDay({ async: false })
 }
 
@@ -90,7 +137,7 @@ function handleSaveShoppingDay({ async }: { async: boolean }) {
 
 const productsSuggestions = computed(() =>
     computedProducts.value.filter(
-        ({ id }) => !updateProductsForm.products.includes(id)
+        ({ id }) => !selectedIds.value.includes(id)
     )
 )
 
@@ -100,16 +147,18 @@ const {
     handleSubmit: handleSubmitDate,
 } = useEditShoppingDay(
     shoppingDay,
-    computed(() => ({ products: updateProductsForm.products }))
+    computed(() => ({ products: selectedIds.value }))
 )
 
 const estimatedTotal = computed(() =>
-    updateProductsForm.products.reduce((total, id) => {
-        const product = props.products.find((product) => product.id === id)
+    selectedIds.value.reduce((total, productId) => {
+        const product = props.products.find((p) => p.id === productId)
         if (!product || !product.lastPrice) return total
 
-        const quantity = parseInt(product.name.split("-").at(1) ?? "")
-        if (Number.isNaN(quantity)) return total + product.lastPrice
+        const item = itemForProduct(productId)
+        const quantity = item
+            ? getQuantity(item.id)
+            : parseInt(product.name.split("-").at(1) ?? "") || 1
 
         return total + product.lastPrice * quantity
     }, 0)
@@ -120,7 +169,7 @@ const estimatedTotal = computed(() =>
     <Head :title="`Día de compras: ${formatDate(props.shoppingDay.date)}`" />
 
     <AppLayout :breadcrumbs="breadcrumbs">
-        <header class="p-3 top-0 sticky bg-background z-10 space-y-1">
+        <header class="p-3 top-0 sticky bg-background z-10 space-y-2">
             <div class="w-full flex justify-between items-center">
                 <form @submit.prevent="handleSubmitDate">
                     <EditShoppingDayDateInput
@@ -137,7 +186,29 @@ const estimatedTotal = computed(() =>
                 </AppButton>
             </div>
 
-            <div>Total estimado: {{ formatCurrency(estimatedTotal) }}</div>
+            <div class="text-sm text-muted-foreground">
+                Total estimado: {{ formatCurrency(estimatedTotal) }}
+            </div>
+
+            <div class="relative">
+                <Search
+                    class="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
+                />
+                <AppInput
+                    v-model="searchQuery"
+                    placeholder="Buscar producto..."
+                    class="pl-8 pr-8"
+                    autocomplete="off"
+                />
+                <button
+                    v-if="searchQuery"
+                    type="button"
+                    class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    @click="searchQuery = ''"
+                >
+                    <X class="size-4" />
+                </button>
+            </div>
         </header>
 
         <form
@@ -153,32 +224,74 @@ const estimatedTotal = computed(() =>
 
         <div class="px-2 py-1 flex gap-3 justify-between flex-col h-full">
             <form
-                class="columns-2"
                 @submit.prevent="handleSaveProducts"
                 id="productsForm"
+                class="space-y-3"
             >
-                <article v-for="product in computedProducts" :key="product.id">
-                    <label
-                        :class="[
-                            'accent-primary dark:accent-secondary',
-                            {
-                                underline:
-                                    !product.lastPrice &&
-                                    updateProductsForm.products.includes(
-                                        product.id
-                                    ),
-                            },
-                        ]"
-                    >
-                        <input
-                            type="checkbox"
-                            v-model="updateProductsForm.products"
-                            @change="autoSaveItems"
-                            :value="product.id"
+                <div v-if="selectedProducts.length > 0">
+                    <p class="text-xs font-medium text-muted-foreground px-2 mb-1">
+                        Seleccionados ({{ selectedProducts.length }})
+                    </p>
+                    <div class="flex flex-col">
+                        <div
+                            v-for="product in selectedProducts"
+                            :key="product.id"
+                            class="flex items-center gap-2 pr-2"
+                        >
+                            <ProductCheckboxItem
+                                class="flex-1 min-w-0"
+                                :product="product"
+                                :checked="true"
+                                @update:checked="
+                                    handleToggleProduct(product.id, $event)
+                                "
+                            />
+                            <QuantityControl
+                                v-if="itemForProduct(product.id)"
+                                :modelValue="
+                                    getQuantity(itemForProduct(product.id)!.id)
+                                "
+                                @update:modelValue="
+                                    handleQuantityChange(
+                                        itemForProduct(product.id)!.id,
+                                        $event
+                                    )
+                                "
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                <Separator
+                    v-if="
+                        selectedProducts.length > 0 &&
+                        availableProducts.length > 0
+                    "
+                />
+
+                <div v-if="availableProducts.length > 0">
+                    <p class="text-xs font-medium text-muted-foreground px-2 mb-1">
+                        Disponibles ({{ availableProducts.length }})
+                    </p>
+                    <div class="columns-2">
+                        <ProductCheckboxItem
+                            v-for="product in availableProducts"
+                            :key="product.id"
+                            :product="product"
+                            :checked="false"
+                            @update:checked="
+                                handleToggleProduct(product.id, $event)
+                            "
                         />
-                        {{ product.name }}
-                    </label>
-                </article>
+                    </div>
+                </div>
+
+                <p
+                    v-if="filteredProducts.length === 0"
+                    class="text-sm text-muted-foreground px-2 py-4 text-center"
+                >
+                    Sin resultados para "{{ searchQuery }}"
+                </p>
             </form>
 
             <div class="flex justify-end">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import vue from "@vitejs/plugin-vue"
 import laravel from "laravel-vite-plugin"
 import path from "path"
 import { resolve } from "node:path"
-import { defineConfig } from "vite"
+import { defineConfig } from "vitest/config"
 
 export default defineConfig({
     plugins: [
@@ -27,5 +27,9 @@ export default defineConfig({
             "@": path.resolve(__dirname, "./resources/js"),
             "ziggy-js": resolve(__dirname, "vendor/tightenco/ziggy"),
         },
+    },
+    test: {
+        environment: "happy-dom",
+        globals: true,
     },
 })


### PR DESCRIPTION
## Summary

- **Responsive grid for Disponibles**: replaces `columns-2` (which could split product names mid-row) with `grid grid-cols-2 sm:grid-cols-3`
- **Quantity picker appears immediately on toggle**: `itemQuantities` is now keyed by product ID (not server item ID) using `reactive()` for correct property-level tracking, so `QuantityControl` shows as soon as a product is selected
- **Quantity sync after first save**: newly-toggled products are created server-side with qty=1; a stale-check in `onSuccess` detects mismatches and fires a follow-up PATCH to sync the user's intended quantity
- **Autosave status indicator**: shows `Pendiente… / Guardando… / Guardado` inline next to the estimated total
- **Empty state**: friendly message when no products exist yet
- **Footer polish**: removes leftover `basis-1/2` from the Delete button and adds a `border-t` separator above it

## Test plan

- [ ] Toggle a product from Disponibles → quantity picker appears immediately at qty=1
- [ ] Change quantity before autosave fires → 6 s later a PATCH goes out; if a second PATCH fires it carries the correct quantity
- [ ] Autosave status cycles through Pendiente… → Guardando… → Guardado → clears
- [ ] Disponibles list reflows from 2 to 3 columns at the `sm` breakpoint with no broken names
- [ ] Delete button is right-aligned at natural width with a visible top border separator
- [ ] `sail npm run test` — 37 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)